### PR TITLE
Add missing hyphens in content

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -6,5 +6,5 @@ body:
 
 The Pallets Project is a collection of Python web development libraries that
 were independently developed by Armin Ronacher and later used as the basis of
-the Flask microframework.  Today the Pallets Project is a community driven
+the Flask microframework.  Today the Pallets Project is a community-driven
 organization with the goal to maintain and improve those libraries.

--- a/content/projects/jinja/contents.lr
+++ b/content/projects/jinja/contents.lr
@@ -2,7 +2,7 @@ name: Jinja
 ---
 body:
 
-Jinja2 is a full featured template engine for Python. It has full unicode
+Jinja2 is a full-featured template engine for Python. It has full unicode
 support, an optional integrated sandboxed execution environment,
 widely used and BSD licensed.
 


### PR DESCRIPTION
I noticed these two missing on the homepage.
