### PR TITLE
Fix footer icon bar style

### DIFF
--- a/webpack/scss/main.scss
+++ b/webpack/scss/main.scss
@@ -73,7 +73,7 @@ footer {
   line-height: 36px;
 
   .icon-bar {
-    font-size: 28px;
+    font-size: 26px;
     a {
       margin-right: 10px;
       text-decoration: none;


### PR DESCRIPTION
it's my fault, because of last pull request website footer style is broken.

now: 
![image](https://user-images.githubusercontent.com/3297859/45629019-fc5cd280-bac7-11e8-97c4-97a2f1d2f18a.png)

fixed: 
![image](https://user-images.githubusercontent.com/3297859/45629178-5eb5d300-bac8-11e8-9ea2-c7ab4651eab9.png)
