### PR TITLE
do not encourage Python 2 print statements in examples

### DIFF
--- a/content/governance/sourcecode/python-styleguide/contents.lr
+++ b/content/governance/sourcecode/python-styleguide/contents.lr
@@ -64,10 +64,10 @@ segments in code.
 
 ```python
 def hello(name):
-    print 'Hello %s!' % name
+    print('Hello %s!' % name)
 
 def goodbye(name):
-    print 'See you %s.' % name
+    print('See you %s.' % name)
 ```
 
 ```python


### PR DESCRIPTION
Rather show prints as function calls as example.