### PR TITLE
Updated contents.lr to be grammatically correct

### DIFF
--- a/content/governance/structure/contents.lr
+++ b/content/governance/structure/contents.lr
@@ -6,7 +6,7 @@ body:
 
 The pallets project does not have a strong structure yet and maybe that will
 not change.  The head of the information organization is [Armin
-Ronacher](/people/mitsuhiko/) and potentially controversially decisions are signed
+Ronacher](/people/mitsuhiko/) and potentially controversial decisions are signed
 off through him.
 
 ## Decision Making Process


### PR DESCRIPTION
Hey all, this pr just fixes a minor grammar issue. You shouldn't use 'ly' on both the descriptor and the object of the descriptor