### PR TITLE
Add Discord link

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -61,6 +61,8 @@
             ><i class="fa fa-github"></i></a>
           <a href="https://twitter.com/PalletsTeam/" title="Pallets on Twitter"
             ><i class="fa fa-twitter"></i></a>
+          <a href="https://discord.gg/pallets/" title="Chat on Discord"
+            ><i class="fa fa-comment"></i></a>
           {%- if this.path %}
           <a href="https://github.com/pallets/website/tree/master/content{{ this.path.split('@')[0]
             }}/contents.lr" title="View source for this page"><i class="fa fa-code"></i></a>


### PR DESCRIPTION
Fix #51. Just a quick fix with `fa-comment`.

![image](https://user-images.githubusercontent.com/12967000/103849428-986ad780-50df-11eb-91e7-376398cfbdcb.png)


