### PR TITLE
Fix navbar collapse on mobile

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const webpack = require('webpack')
 
 module.exports = {
   mode: 'production',
@@ -41,6 +42,10 @@ module.exports = {
     ]
   },
   plugins: [
-    new MiniCssExtractPlugin()
+    new MiniCssExtractPlugin(),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    })
   ]
 }


### PR DESCRIPTION
The navbar toggle was broken on mobile. A JS error indicated jQuery was not found.
I've adjusted webpack.config.js to resolve this error.