### PR TITLE
fix Discord invite url

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -62,7 +62,7 @@
             ><i class="fa fa-github"></i></a>
           <a href="https://twitter.com/PalletsTeam/" title="Pallets on Twitter"
             ><i class="fa fa-twitter"></i></a>
-          <a href="https://discord.gg/pallets/" title="Chat on Discord"
+          <a href="https://discord.gg/pallets" title="Chat on Discord"
             ><i class="fa fa-comment"></i></a>
           {%- if this.path %}
           <a href="https://github.com/pallets/website/tree/master/content{{ this.path.split('@')[0]


### PR DESCRIPTION
The prior URL redirected to discord.com instead of leading the user to the Discord invite page for Pallets.